### PR TITLE
TVPF-46094: disable parallel compilation

### DIFF
--- a/mDNSPosix/Makefile
+++ b/mDNSPosix/Makefile
@@ -232,6 +232,8 @@ MDNSCFLAGS = $(CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_OS) $(CFLAGS_DEBUGGING)
 
 #############################################################################
 
+.NOTPARALLEL:
+
 all: setup Daemon libdns_sd Clients SAClient SAResponder SAProxyResponder NetMonitor $(OPTIONALTARG)
 
 install: setup InstalledStartup InstalledDaemon InstalledLib InstalledManPages InstalledClients $(OPTINSTALL)


### PR DESCRIPTION
Build fails from time to time because some c.o object is not ready and required by another c.o:
**mDNSPosix.c or mDNSUNP.c requires PosixDaemon.c** 

Solution is to disable parallel compilation to allow objects to compile serially.
